### PR TITLE
Fix: Show error card when update candy machine failed

### DIFF
--- a/components/forms/UpdateCandyMachine.tsx
+++ b/components/forms/UpdateCandyMachine.tsx
@@ -146,13 +146,12 @@ const UpdateCreateCandyMachineForm: FC<{
                     cache: await cache.text(),
                     newAuthority: values['new-authority'],
                 })
-                setIsInteractingWithCM(false)
                 setStatus('Candy Machine updated successfully!')
             }
         } catch (err) {
-            setIsInteractingWithCM(false)
-            setStatus('Candy Machine update was not successful, please re-run.')
+            setErrorMessage('Candy Machine update was not successful, please re-run.')
         }
+        setIsInteractingWithCM(false)
     }
 
     return (

--- a/lib/candy-machine/update.ts
+++ b/lib/candy-machine/update.ts
@@ -56,5 +56,6 @@ export async function updateV2({
         saveCache(cacheName, env, cacheContent)
     } catch (err) {
         console.error(err)
+        throw new Error()
     }
 }


### PR DESCRIPTION
Fixes #161

## Changes

  - Add throw new error in update candy machine catch
  
### Checks

* [X] Have you catchup your branch with the latest state in base?
* [X] Have you lint your code locally prior to submission?
* [X] Have you reviewed your proposed changes and removed debris?
* [X] Have you successfully ran due tests with your changes?


