### PR TITLE
fix: cannot assign to read only property `_nextClientSubscriptionId`

### DIFF
--- a/components/forms/UpdateCandyMachine.tsx
+++ b/components/forms/UpdateCandyMachine.tsx
@@ -1,6 +1,6 @@
 import { AnchorProvider, BN } from '@project-serum/anchor'
 import { useAnchorWallet, useWallet } from '@solana/wallet-adapter-react'
-import { LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js'
+import { LAMPORTS_PER_SOL, PublicKey, Connection } from '@solana/web3.js'
 import { useForm, useRPC, useUploadCache } from 'hooks'
 import { updateV2 } from 'lib/candy-machine'
 import { DEFAULT_GATEKEEPER } from 'lib/candy-machine/constants'
@@ -18,7 +18,7 @@ const UpdateCreateCandyMachineForm: FC<{
 }> = ({ fetchedValues, candyMachinePubkey }) => {
     const { publicKey } = useWallet()
     const anchorWallet = useAnchorWallet()
-    const { connection } = useRPC()
+    const { connection, network } = useRPC()
 
     const { cache, uploadCache } = useUploadCache()
     const [isInteractingWithCM, setIsInteractingWithCM] = useState(false)
@@ -88,8 +88,8 @@ const UpdateCreateCandyMachineForm: FC<{
                 uuid: null,
             }
 
-            if (publicKey && anchorWallet && candyMachinePubkey && connection) {
-                const provider = new AnchorProvider(connection, anchorWallet, {
+            if (publicKey && anchorWallet && candyMachinePubkey && connection && network) {
+                const provider = new AnchorProvider(new Connection(connection.rpcEndpoint), anchorWallet, {
                     preflightCommitment: 'recent',
                 })
 

--- a/hooks/useRemoveCandyMachineAccount.tsx
+++ b/hooks/useRemoveCandyMachineAccount.tsx
@@ -1,6 +1,6 @@
 import { AnchorProvider, Program } from '@project-serum/anchor'
 import { AnchorWallet, useAnchorWallet } from '@solana/wallet-adapter-react'
-import { LAMPORTS_PER_SOL, PublicKey, TransactionInstruction } from '@solana/web3.js'
+import { LAMPORTS_PER_SOL, PublicKey, TransactionInstruction, Connection } from '@solana/web3.js'
 import { useRPC } from 'hooks'
 import { loadCandyProgramV2 } from 'lib/candy-machine/upload/config'
 import { sendTransactionWithRetryWithKeypair } from 'lib/candy-machine/upload/transactions'
@@ -16,7 +16,7 @@ const useRemoveCandyMachineAccount = (accounts: string[]) => {
 
     const removeAccount = async (candyMachineAccount: string) => {
         if (!anchorWallet || !connection) return
-        const provider = new AnchorProvider(connection, anchorWallet, {
+        const provider = new AnchorProvider(new Connection(connection.rpcEndpoint), anchorWallet, {
             preflightCommitment: 'recent',
         })
 


### PR DESCRIPTION
The update and delete forms have the same error as the create form, we should also add `<Connection>`